### PR TITLE
declare err variable in main so step 8 will compile

### DIFF
--- a/v2.4.0/lesson2/cellfund_less2_exer2/src/main.c
+++ b/v2.4.0/lesson2/cellfund_less2_exer2/src/main.c
@@ -32,6 +32,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 
 int main(void)
 {
+	int err;
 	if (dk_leds_init() != 0) {
 		LOG_ERR("Failed to initialize the LEDs Library");
 	}


### PR DESCRIPTION
As the tutorial is written today (2023-08-30), lesson 2 exercise 2 will not compile because it attempts to assign the variable err that is not declared.  This fixes this