### PR TITLE
Fix: lesson5 exer1 solution for nRF9151-DK

### DIFF
--- a/v2.4.0-v2.x.x/lesson5/cellfund_less5_exer1_solution/src/main.c
+++ b/v2.4.0-v2.x.x/lesson5/cellfund_less5_exer1_solution/src/main.c
@@ -309,7 +309,7 @@ static int client_handle_response(uint8_t *buf, int received)
 static void button_handler(uint32_t button_state, uint32_t has_changed)
 {
 	/* STEP 10 - Send a GET request or PUT request upon button triggers */
-	#if defined (CONFIG_BOARD_NRF9160DK_NRF9160_NS) || (CONFIG_BOARD_NRF9161DK_NRF9161_NS)
+	#if defined(CONFIG_BOARD_NRF9160DK_NRF9160_NS) || defined(CONFIG_BOARD_NRF9151DK_NRF9151_NS)
 	if (has_changed & DK_BTN1_MSK && button_state & DK_BTN1_MSK) {
 		client_get_send();
 	} else if (has_changed & DK_BTN2_MSK && button_state & DK_BTN2_MSK) {


### PR DESCRIPTION
The original solution didn't check for nRF9151-DK and therefore never `calls client_get_send()` or `client_put_send()` after a button press on button 1 or 2 on this DK.
Added `defined(CONFIG_BOARD_NRF9151DK_NRF9151_NS)` to the #if.
