### PR TITLE
Minor fixes to remove warnings and avoid mismatches

### DIFF
--- a/v2.8.x-v2.7.0/l6/l6_e2/src/main.c
+++ b/v2.8.x-v2.7.0/l6/l6_e2/src/main.c
@@ -57,6 +57,7 @@ static int server_resolve(void)
 	}
 
 	struct sockaddr_in *server4 = ((struct sockaddr_in *)&server);
+	
 	server4->sin_addr.s_addr =
 		((struct sockaddr_in *)result->ai_addr)->sin_addr.s_addr;
 	server4->sin_family = AF_INET;
@@ -87,7 +88,7 @@ static int server_connect(void)
 		LOG_ERR("Connect failed : %d", errno);
 		return -errno;
 	}
-	LOG_INF("Successfully connected");
+	LOG_INF("Successfully connected to server");
 
 	return 0;
 }
@@ -110,9 +111,9 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 				evt->rrc_mode == LTE_LC_RRC_MODE_CONNECTED ?
 				"Connected" : "Idle");
 		break;
-	/* STEP 9.1 - On event PSM update, print PSM paramters and check if was enabled */
+	/* STEP 9.1 - On event PSM update, print PSM parameters and check if was enabled */
 
-	/* STEP 9.2 - On event eDRX update, print eDRX paramters */
+	/* STEP 9.2 - On event eDRX update, print eDRX parameters */
 
 	default:
 		break;
@@ -140,7 +141,6 @@ static int modem_configure(void)
 	}
 	#endif
 
-
 	/* STEP 8 - Request PSM and eDRX from the network */
 
 	
@@ -150,7 +150,6 @@ static int modem_configure(void)
 		LOG_ERR("Error in lte_lc_connect_async, error: %d", err);
 		return err;
 	}
-
 
 	k_sem_take(&lte_connected, K_FOREVER);
 	LOG_INF("Connected to LTE network");
@@ -163,7 +162,7 @@ static void print_fix_data(struct nrf_modem_gnss_pvt_data_frame *pvt_data)
 {
 	LOG_INF("Latitude:       %.06f", pvt_data->latitude);
 	LOG_INF("Longitude:      %.06f", pvt_data->longitude);
-	LOG_INF("Altitude:       %.01f m", pvt_data->altitude);
+	LOG_INF("Altitude:       %.01f m", (double)pvt_data->altitude);
 	LOG_INF("Time (UTC):     %02u:%02u:%02u.%03u",
 	       pvt_data->datetime.hour,
 	       pvt_data->datetime.minute,

--- a/v2.8.x-v2.7.0/l6/l6_e2_sol/src/main.c
+++ b/v2.8.x-v2.7.0/l6/l6_e2_sol/src/main.c
@@ -112,7 +112,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 				evt->rrc_mode == LTE_LC_RRC_MODE_CONNECTED ?
 				"Connected" : "Idle");
 		break;
-	/* STEP 9.1 - On event PSM update, print PSM paramters and check if was enabled */
+	/* STEP 9.1 - On event PSM update, print PSM parameters and check if was enabled */
 	case LTE_LC_EVT_PSM_UPDATE:
 		LOG_INF("PSM parameter update: Periodic TAU: %d s, Active time: %d s",
 			evt->psm_cfg.tau, evt->psm_cfg.active_time);
@@ -120,7 +120,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 			LOG_ERR("Network rejected PSM parameters. Failed to enable PSM");
 		}
 		break;
-	/* STEP 9.2 - On event eDRX update, print eDRX paramters */
+	/* STEP 9.2 - On event eDRX update, print eDRX parameters */
 	case LTE_LC_EVT_EDRX_UPDATE:
 		LOG_INF("eDRX parameter update: eDRX: %f, PTW: %f",
 			(double)evt->edrx_cfg.edrx, (double)evt->edrx_cfg.ptw);

--- a/v2.8.x-v2.7.0/l7/l7_e1/src/main.c
+++ b/v2.8.x-v2.7.0/l7/l7_e1/src/main.c
@@ -173,7 +173,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 		break;
 	case LTE_LC_EVT_EDRX_UPDATE:
 		LOG_INF("eDRX parameter update: eDRX: %f, PTW: %f",
-			evt->edrx_cfg.edrx, evt->edrx_cfg.ptw);
+			(double)evt->edrx_cfg.edrx, (double)evt->edrx_cfg.ptw);
 		break;
      default:
              break;


### PR DESCRIPTION
There were discrepancies between the code users would copy from the course materials and the solution code.  Additionally, there were warnings related to missing type casts.