### PR TITLE
Removed redundant check of NCS_VERSION_NUMBER in irrelevant version directories

### DIFF
--- a/v2.9.0-v2.7.0/l2/l2_e2_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l2/l2_e2_sol/src/main.c
@@ -59,15 +59,6 @@ static int modem_configure(void)
 		LOG_ERR("Failed to initialize the modem library, error: %d", err);
 		return err;
 	}
-
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l3/l3_e1/src/main.c
+++ b/v2.9.0-v2.7.0/l3/l3_e1/src/main.c
@@ -89,15 +89,6 @@ static int modem_configure(void)
 		LOG_ERR("Failed to initialize the modem library, error: %d", err);
 		return err;
 	}
-
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l3/l3_e1_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l3/l3_e1_sol/src/main.c
@@ -130,15 +130,6 @@ static int modem_configure(void)
 		LOG_ERR("Failed to initialize the modem library, error: %d", err);
 		return err;
 	}
-
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l4/l4_e1/src/main.c
+++ b/v2.9.0-v2.7.0/l4/l4_e1/src/main.c
@@ -58,15 +58,6 @@ static int modem_configure(void)
 		LOG_ERR("Failed to initialize the modem library, error: %d", err);
 		return err;
 	}
-
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l4/l4_e1/src/mqtt_connection.c
+++ b/v2.9.0-v2.7.0/l4/l4_e1/src/mqtt_connection.c
@@ -11,11 +11,8 @@
 #include <dk_buttons_and_leds.h>
 #include "mqtt_connection.h"
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else
 #include <zephyr/random/random.h>
-#endif
+
 
 /* Buffers for MQTT client. */
 static uint8_t rx_buffer[CONFIG_MQTT_MESSAGE_BUFFER_SIZE];

--- a/v2.9.0-v2.7.0/l4/l4_e1_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l4/l4_e1_sol/src/main.c
@@ -59,15 +59,6 @@ static int modem_configure(void)
 		LOG_ERR("Failed to initialize the modem library, error: %d", err);
 		return err;
 	}
-
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l4/l4_e1_sol/src/mqtt_connection.c
+++ b/v2.9.0-v2.7.0/l4/l4_e1_sol/src/mqtt_connection.c
@@ -11,11 +11,7 @@
 #include <dk_buttons_and_leds.h>
 #include "mqtt_connection.h"
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else 
 #include <zephyr/random/random.h>
-#endif
 
 /* Buffers for MQTT client. */
 static uint8_t rx_buffer[CONFIG_MQTT_MESSAGE_BUFFER_SIZE];

--- a/v2.9.0-v2.7.0/l4/l4_e2/src/main.c
+++ b/v2.9.0-v2.7.0/l4/l4_e2/src/main.c
@@ -62,14 +62,6 @@ static int modem_configure(void)
 
 	/* STEP 4.3 - Store the certificate in the modem while the modem is in offline mode  */
 
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l4/l4_e2/src/mqtt_connection.c
+++ b/v2.9.0-v2.7.0/l4/l4_e2/src/mqtt_connection.c
@@ -11,11 +11,7 @@
 #include <dk_buttons_and_leds.h>
 #include "mqtt_connection.h"
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else 
 #include <zephyr/random/random.h>
-#endif
 
 /* STEP 2.4 - Include the header file for the modem key management library */
 

--- a/v2.9.0-v2.7.0/l4/l4_e2_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l4/l4_e2_sol/src/main.c
@@ -67,14 +67,6 @@ static int modem_configure(void)
 		return err;
 	}
 
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l4/l4_e2_sol/src/mqtt_connection.c
+++ b/v2.9.0-v2.7.0/l4/l4_e2_sol/src/mqtt_connection.c
@@ -11,11 +11,7 @@
 #include <dk_buttons_and_leds.h>
 #include "mqtt_connection.h"
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else 
 #include <zephyr/random/random.h>
-#endif
 
 /* STEP 2.4 - Include the header for the Modem Key Management library */
 #include <modem/modem_key_mgmt.h>

--- a/v2.9.0-v2.7.0/l5/l5_e1/src/main.c
+++ b/v2.9.0-v2.7.0/l5/l5_e1/src/main.c
@@ -15,11 +15,7 @@
 #include <modem/nrf_modem_lib.h>
 #include <modem/lte_lc.h>
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else 
 #include <zephyr/random/random.h>
-#endif
 
 
 /* STEP 2.2 - Include the header file for the CoAP library */
@@ -142,15 +138,6 @@ static int modem_configure(void)
 		LOG_ERR("Failed to initialize the modem library, error: %d", err);
 		return err;
 	}
-
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l5/l5_e1_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l5/l5_e1_sol/src/main.c
@@ -15,11 +15,7 @@
 #include <modem/nrf_modem_lib.h>
 #include <modem/lte_lc.h>
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else 
 #include <zephyr/random/random.h>
-#endif
 
 /* STEP 2.2 - Include the header file for the CoAP library */
 #include <zephyr/net/coap.h>
@@ -143,14 +139,6 @@ static int modem_configure(void)
 		return err;
 	}
 
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l5/l5_e2/src/main.c
+++ b/v2.9.0-v2.7.0/l5/l5_e2/src/main.c
@@ -16,11 +16,7 @@
 #include <modem/nrf_modem_lib.h>
 #include <modem/lte_lc.h>
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else 
 #include <zephyr/random/random.h>
-#endif
 
 /* STEP 4.2 - Include the header files for the modem key management library and TLS credentials API */
 
@@ -160,14 +156,6 @@ static int modem_configure(void)
 	/* STEP 8.2 - Write the PSK to the modem */
 
 
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l5/l5_e2_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l5/l5_e2_sol/src/main.c
@@ -16,11 +16,7 @@
 #include <modem/nrf_modem_lib.h>
 #include <modem/lte_lc.h>
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else 
 #include <zephyr/random/random.h>
-#endif
 
 /* STEP 4.2 - Include the header files for the modem key management library and TLS credentials API */
 #include <modem/modem_key_mgmt.h>
@@ -196,15 +192,6 @@ static int modem_configure(void)
 		LOG_ERR("Failed to write identity: %d\n", err);
 		return err;
 	}
-
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);

--- a/v2.9.0-v2.7.0/l6/l6_e1/src/main.c
+++ b/v2.9.0-v2.7.0/l6/l6_e1/src/main.c
@@ -38,14 +38,6 @@ static int modem_configure(void)
 		return err;
 	}
 
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE Link Controller, error: %d", err);
-		return err;
-	}
-	#endif
 
 	return 0;
 }

--- a/v2.9.0-v2.7.0/l6/l6_e1_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l6/l6_e1_sol/src/main.c
@@ -40,15 +40,6 @@ static int modem_configure(void)
 		return err;
 	}
 
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE Link Controller, error: %d", err);
-		return err;
-	}
-	#endif
-
 	return 0;
 }
 

--- a/v2.9.0-v2.7.0/l6/l6_e2/src/main.c
+++ b/v2.9.0-v2.7.0/l6/l6_e2/src/main.c
@@ -132,14 +132,6 @@ static int modem_configure(void)
 		return err;
 	}
 
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 
 	/* STEP 8 - Request PSM and eDRX from the network */
 

--- a/v2.9.0-v2.7.0/l6/l6_e2_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l6/l6_e2_sol/src/main.c
@@ -141,15 +141,6 @@ static int modem_configure(void)
 		LOG_ERR("Failed to initialize the modem library, error: %d", err);
 		return err;
 	}
-
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	/* STEP 8 - Request PSM and eDRX from the network */
 	err = lte_lc_psm_req(true);

--- a/v2.9.0-v2.7.0/l7/l7_e1/src/main.c
+++ b/v2.9.0-v2.7.0/l7/l7_e1/src/main.c
@@ -16,11 +16,7 @@
 #include <modem/nrf_modem_lib.h>
 #include <modem/lte_lc.h>
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else 
 #include <zephyr/random/random.h>
-#endif
 
 /* STEP 4.2 - Include the header files for the modem key management library and TLS credentials API */
 #include <modem/modem_key_mgmt.h>
@@ -205,15 +201,6 @@ static int modem_configure(void)
 		LOG_ERR("Failed to write identity: %d\n", err);
 		return err;
 	}
-
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 
 	err = lte_lc_psm_req(true);
 	if (err) {

--- a/v2.9.0-v2.7.0/l7/l7_e1_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l7/l7_e1_sol/src/main.c
@@ -16,11 +16,7 @@
 #include <modem/nrf_modem_lib.h>
 #include <modem/lte_lc.h>
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else 
 #include <zephyr/random/random.h>
-#endif
 
 /* STEP 4.2 - Include the header files for the modem key management library and TLS credentials API */
 #include <modem/modem_key_mgmt.h>
@@ -206,14 +202,6 @@ static int modem_configure(void)
 		return err;
 	}
 
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 
 	err = lte_lc_psm_req(true);
 	if (err) {

--- a/v2.9.0-v2.7.0/l8/l8_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l8/l8_sol/src/main.c
@@ -18,11 +18,7 @@
 #include <dk_buttons_and_leds.h>
 #include <nrf_modem_gnss.h>
 
-#if NCS_VERSION_NUMBER < 0x20600
-#include <zephyr/random/rand32.h>
-#else 
 #include <zephyr/random/random.h>
-#endif
 
 #define SEC_TAG 12
 #define APP_COAP_SEND_INTERVAL_MS 60000
@@ -335,14 +331,6 @@ static int modem_configure(void)
 		return err;
 	}
 
-	/* lte_lc_init deprecated in >= v2.6.0 */
-	#if NCS_VERSION_NUMBER < 0x20600
-	err = lte_lc_init();
-	if (err) {
-		LOG_ERR("Failed to initialize LTE link control library, error: %d", err);
-		return err;
-	}
-	#endif
 	
 	LOG_INF("Connecting to LTE network");
 	err = lte_lc_connect_async(lte_handler);


### PR DESCRIPTION
No need to check if NCS_VERSION_NUMBER less than 2.6.0 in directory versions > 2.6.0. 