### PR TITLE
mqtt_disconnect() has two parameters

### DIFF
--- a/l4/l4_e1/src/main.c
+++ b/l4/l4_e1/src/main.c
@@ -160,7 +160,7 @@ do_connect:
 
 	LOG_INF("Disconnecting MQTT client");
 
-	err = mqtt_disconnect(&client);
+	err = mqtt_disconnect(&client, NULL);
 	if (err) {
 		LOG_ERR("Could not disconnect MQTT client: %d", err);
 	}

--- a/l4/l4_e1_sol/src/main.c
+++ b/l4/l4_e1_sol/src/main.c
@@ -123,7 +123,6 @@ do_connect:
 		k_sleep(K_SECONDS(CONFIG_MQTT_RECONNECT_DELAY_S));
 	}
 
-	LOG_INF("Connection to broker using mqtt_connect");
 	err = mqtt_connect(&client);
 	if (err) {
 		LOG_ERR("Error in mqtt_connect: %d", err);
@@ -170,7 +169,7 @@ do_connect:
 
 	LOG_INF("Disconnecting MQTT client");
 
-	err = mqtt_disconnect(&client);
+	err = mqtt_disconnect(&client, NULL);
 	if (err) {
 		LOG_ERR("Could not disconnect MQTT client: %d", err);
 	}

--- a/l4/l4_e1_sol/src/mqtt_connection.c
+++ b/l4/l4_e1_sol/src/mqtt_connection.c
@@ -183,7 +183,7 @@ void mqtt_evt_handler(struct mqtt_client *const c,
 			LOG_ERR("get_received_payload failed: %d", err);
 			LOG_INF("Disconnecting MQTT client...");
 
-			err = mqtt_disconnect(c);
+			err = mqtt_disconnect(c, NULL);
 			if (err) {
 				LOG_ERR("Could not disconnect: %d", err);
 			}

--- a/l4/l4_e2/src/main.c
+++ b/l4/l4_e2/src/main.c
@@ -171,7 +171,7 @@ do_connect:
 
 	LOG_INF("Disconnecting MQTT client");
 
-	err = mqtt_disconnect(&client);
+	err = mqtt_disconnect(&client, NULL);
 	if (err) {
 		LOG_ERR("Could not disconnect MQTT client: %d", err);
 	}

--- a/l4/l4_e2/src/mqtt_connection.c
+++ b/l4/l4_e2/src/mqtt_connection.c
@@ -187,7 +187,7 @@ void mqtt_evt_handler(struct mqtt_client *const c,
 			LOG_ERR("get_received_payload failed: %d", err);
 			LOG_INF("Disconnecting MQTT client...");
 
-			err = mqtt_disconnect(c);
+			err = mqtt_disconnect(c, NULL);
 			if (err) {
 				LOG_ERR("Could not disconnect: %d", err);
 			}

--- a/l4/l4_e2_sol/src/certificate.h
+++ b/l4/l4_e2_sol/src/certificate.h
@@ -15,3 +15,4 @@
 "AjAZyj0Kd+lO8YQZ7SJ+h3n489uz+ww9RMUtpZWXSp8hO0vqCBce2tkLrSWVzGFn\n" \
 "EIY=\n" \
 "-----END CERTIFICATE-----\n" \
+

--- a/l4/l4_e2_sol/src/main.c
+++ b/l4/l4_e2_sol/src/main.c
@@ -175,7 +175,7 @@ do_connect:
 
 	LOG_INF("Disconnecting MQTT client");
 
-	err = mqtt_disconnect(&client);
+	err = mqtt_disconnect(&client, NULL);
 	if (err) {
 		LOG_ERR("Could not disconnect MQTT client: %d", err);
 	}

--- a/l4/l4_e2_sol/src/mqtt_connection.c
+++ b/l4/l4_e2_sol/src/mqtt_connection.c
@@ -223,7 +223,7 @@ void mqtt_evt_handler(struct mqtt_client *const c,
 			LOG_ERR("get_received_payload failed: %d", err);
 			LOG_INF("Disconnecting MQTT client...");
 
-			err = mqtt_disconnect(c);
+			err = mqtt_disconnect(c, NULL);
 			if (err) {
 				LOG_ERR("Could not disconnect: %d", err);
 			}


### PR DESCRIPTION
mqtt_disconnect() call changed in v3.0.0 to two parameters